### PR TITLE
style: :art: update global yellow color tone across theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,8 +44,8 @@ body {
     --primary-foreground: 0 0% 96%;
     /* off white */
 
-    --secondary: 35 67% 48%;
-    /* mustard yellow */
+    --secondary: 66 73% 55%;
+    /* new yellow */
     --secondary-foreground: 0 0% 0%;
     /* black */
 
@@ -54,8 +54,8 @@ body {
     --muted-foreground: 0 0% 66%;
     /* warm gray */
 
-    --accent: 35 67% 48%;
-    /* mustard yellow */
+    --accent: 66 73% 55%;
+    /* new yellow */
     --accent-foreground: 0 0% 0%;
     /* black */
 
@@ -67,16 +67,16 @@ body {
     /* Borders, inputs and rings */
     --border: 0 0% 14.9%;
     --input: 0 0% 14.9%;
-    --ring: 35 67% 48%;
-    /* mustard yellow */
+    --ring: 66 73% 55%;
+    /* new yellow */
 
     /* Chart colors */
     --chart-1: 0 0% 0%;
     /* black */
     --chart-2: 4 74% 36%;
     /* dark red */
-    --chart-3: 35 67% 48%;
-    /* mustard yellow */
+    --chart-3: 66 73% 55%;
+    /* new yellow */
     --chart-4: 32 100% 40%;
     /* burnt orange */
     --chart-5: 0 0% 66%;
@@ -97,8 +97,8 @@ body {
     --sidebar-accent-foreground: 0 0% 96%;
 
     --sidebar-border: 0 0% 14.9%;
-    --sidebar-ring: 35 67% 48%;
-    /* mustard yellow */
+    --sidebar-ring: 66 73% 55%;
+    /* new yellow */
   }
 
   .dark {
@@ -117,8 +117,8 @@ body {
     --primary-foreground: 0 0% 96%;
     /* off white */
 
-    --secondary: 35 67% 48%;
-    /* mustard yellow */
+    --secondary: 66 73% 55%;
+    /* new yellow */
     --secondary-foreground: 0 0% 0%;
     /* black */
 
@@ -126,8 +126,8 @@ body {
     --muted-foreground: 0 0% 66%;
     /* warm gray */
 
-    --accent: 35 67% 48%;
-    /* mustard yellow */
+    --accent: 66 73% 55%;
+    /* new yellow */
     --accent-foreground: 0 0% 0%;
     /* black */
 
@@ -138,15 +138,15 @@ body {
 
     --border: 0 0% 14.9%;
     --input: 0 0% 14.9%;
-    --ring: 35 67% 48%;
-    /* mustard yellow */
+    --ring: 66 73% 55%;
+    /* new yellow */
 
     --chart-1: 0 0% 0%;
     /* black */
     --chart-2: 4 74% 36%;
     /* dark red */
-    --chart-3: 35 67% 48%;
-    /* mustard yellow */
+    --chart-3: 66 73% 55%;
+    /* new yellow */
     --chart-4: 32 100% 40%;
     /* burnt orange */
     --chart-5: 0 0% 66%;
@@ -164,8 +164,8 @@ body {
     --sidebar-accent-foreground: 0 0% 96%;
 
     --sidebar-border: 0 0% 14.9%;
-    --sidebar-ring: 35 67% 48%;
-    /* mustard yellow */
+    --sidebar-ring: 66 73% 55%;
+    /* new yellow */
   }
 }
 


### PR DESCRIPTION
Replaced mustard yellow with new yellow tone in global CSS variables for secondary, accent, ring, chart, and sidebar elements. Improves branding consistency and visual design.