### PR TITLE
feat: 📝 add promotion notes and update banner UI

### DIFF
--- a/src/actions/promotions/get-promotions.ts
+++ b/src/actions/promotions/get-promotions.ts
@@ -17,7 +17,8 @@ export async function getPromotions(): Promise<Promotion[]> {
       {
         id: randomUUID(),
         name: 'COMBO BURGER INDIVIDUAL',
-        description: 'Hamburguesa de especialidad  + papas + bebida de 1/2 Lt.',
+        description: 'Hamburguesa de especialidad  + Papas + Bebida de 1/2 Lt',
+        notes: 'No aplica en New York y Arrachera',
         discountPercentage: 0,
         originalPrice: 0,
         promoPrice: 149,
@@ -29,7 +30,8 @@ export async function getPromotions(): Promise<Promotion[]> {
       {
         id: randomUUID(),
         name: 'COMBO PAREJA',
-        description: '2 Burgers + 1 Reca Litro + 1 papas',
+        description: '2 Burgers + 1 Reca Litro + 1 Papas',
+        notes: 'No aplica en New York y Arrachera',
         discountPercentage: 0,
         originalPrice: 0,
         promoPrice: 299,
@@ -53,7 +55,8 @@ export async function getPromotions(): Promise<Promotion[]> {
       {
         id: randomUUID(),
         name: 'Lunes 3 x 2 Burges',
-        description: 'No aplica en New York, Crispy, Maradona y Arrachera',
+        description: '',
+        notes: 'No aplica en New York, Crispy, Maradona y Arrachera',
         discountPercentage: 0,
         originalPrice: 0,
         promoPrice: 0,
@@ -65,7 +68,8 @@ export async function getPromotions(): Promise<Promotion[]> {
       {
         id: randomUUID(),
         name: 'Miércoles 3 x 2 Tacos y Gringas',
-        description: 'Solo aplica en Asado y Norteño',
+        description: '',
+        notes: 'Solo aplica en Asado y Norteño',
         discountPercentage: 0,
         originalPrice: 0,
         promoPrice: 0,
@@ -77,7 +81,8 @@ export async function getPromotions(): Promise<Promotion[]> {
       {
         id: randomUUID(),
         name: 'Jueves 3 x 2 Tortas',
-        description: 'Solo aplica en Asado y Norteño',
+        description: '',
+        notes: 'Solo aplica en Asado y Norteño',
         discountPercentage: 0,
         originalPrice: 0,
         promoPrice: 0,

--- a/src/components/promotion-banner.tsx
+++ b/src/components/promotion-banner.tsx
@@ -97,6 +97,7 @@ export function PromotionBanner({ promotions }: PromotionBannerProps) {
             <div className="p-4 flex-grow justify-between flex flex-col">
               <h3 className="font-bold text-xl text-white">{promotion.name}</h3>
               <p className="text-muted-foreground mb-3 text-sm">{promotion.description}</p>
+              <p className="text-muted-foreground mb-3 text-xs">{promotion.notes}</p>
               {
                 promoPrice > 0 && (<div className="flex justify-end items-center mb-4">
                   <span className="text-xl font-bold text-secondary">$ {promoPrice}</span>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -34,6 +34,7 @@ export interface Promotion {
   id: string
   name: string
   description: string
+  notes?: string
   discountPercentage: number
   originalPrice: number
   promoPrice: number


### PR DESCRIPTION
### Changes Made
- feat: 📝 add optional notes field to Promotion type
- feat: 🏷️ move promo restrictions from description to notes
- feat: 🎨 render promotion notes in banner component

### Description of Changes
- Added an optional `notes` field to the `Promotion` interface to better separate promotional conditions and restrictions from the main description.
- Updated existing promotions to move applicability rules (e.g. exclusions like New York or Arrachera) into the new `notes` field, leaving descriptions cleaner and more user-friendly.
- Enhanced the `PromotionBanner` component to display promotion notes below the description, improving clarity for users without cluttering the main promo message.